### PR TITLE
Update TWP10_5_en.rst

### DIFF
--- a/_sources/lectures/TWP10/TWP10_5_en.rst
+++ b/_sources/lectures/TWP10/TWP10_5_en.rst
@@ -44,5 +44,5 @@ Nested Structures
     print("Telephone bill : $%6.2f" % (minutes * price))
 
 + Note that nested structures can grow.
-+ Python, given its characteristics, provides the "elif" clause.
++ Python, given its characteristics, provides the ``elif`` clause.
 + It is used to check multiple conditions.


### PR DESCRIPTION
the elif clause formatting is fixed.

Summary
the elif formatting is corrected properly and this fixes the issue https://github.com/PyAr/PyZombis/issues/337

- [x] Variables, functions and comments are translated to Spanish
- [x] Functions follow underscore notation
- [x] Spell check done & typos fixed
- [x] All python code is PEP8 compliant
- [x] Test coverage with Playwright implemented; locators are Pyhton code
- [x] Reviewers assigned (all peers & at least 1 mentor)

Screenshots
![a1](https://github.com/user-attachments/assets/782f1eb9-a295-4c55-93bf-753f65825192)
![a2](https://github.com/user-attachments/assets/3f761a36-2b59-49ba-bb68-b555b7a0cafb)



(prefer Playwright recorded video or animated gif)
